### PR TITLE
Use patches API instead of elasticsearch

### DIFF
--- a/src/app.test.tsx
+++ b/src/app.test.tsx
@@ -4,18 +4,39 @@ import { render, server } from "@hackney/mtfh-test-utils";
 import { screen, waitFor } from "@testing-library/react";
 import { rest } from "msw";
 
+import { Patch } from "@mtfh/common/lib/api/patch/v1";
+
 import App from "./app";
 import { locale } from "./services";
 
 const cookieValue =
   "hackneyToken=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMTUwOTc4MjMzNDMwODYzNjM3NzkiLCJlbWFpbCI6InRlc3RzQGhhY2tuZXkuZ292LnVrIiwiaXNzIjoiSGFja25leSIsIm5hbWUiOiJUZXN0IFRlc3QiLCJpYXQiOjEyMzQ1Njc4OTB9.MRnNHSYMi9majpommvHmSuLMb0tnMvYlX7AXs2DyO6U";
 
+const examplePatch: Patch = {
+  id: "5d59f3af-a692-49ae-9483-f631772ae3ec",
+  name: "Fake_Rupert Fake_Cruickshank",
+  parentId: "26e9426a-59a5-4863-9077-f8cad9d3c82b",
+  domain: "MMH",
+  patchType: "patch",
+  responsibleEntities: [
+    {
+      id: "5d59f3af-a692-49ae-9483-f631772ae3ec",
+      name: "",
+      contactDetails: {
+        emailAddress: "tests@hackney.gov.uk",
+      },
+      responsibleType: "HousingOfficer",
+    },
+  ],
+  versionNumber: 0,
+};
+
 describe("<App />", () => {
   test("it renders correctly without cookie", async () => {
     render(<App />, { url: "/" });
     await waitFor(() => expect(screen.queryByText("Loading...")).not.toBeInTheDocument());
     expect(screen.getAllByText(locale.title));
-    expect(screen.getAllByText(locale.errors.unableToFetchRecord));
+    expect(screen.getAllByText(locale.noPatchAssigned));
   });
 
   test("it renders correctly with cookie", async () => {
@@ -23,32 +44,13 @@ describe("<App />", () => {
       writable: true,
       value: cookieValue,
     });
+
     server.use(
-      rest.get("/api/v1/search/staff/", (req, res, ctx) => {
-        return res(
-          ctx.status(200),
-          ctx.json({
-            results: {
-              staff: [
-                {
-                  firstName: "Fake_Rupert",
-                  lastName: "Fake_Cruickshank",
-                  emailAddress: "tests@hackney.gov.uk",
-                  patches: [
-                    {
-                      id: "5d59f3af-a692-49ae-9483-f631772ae3ec",
-                      name: null,
-                      areaId: "26e9426a-59a5-4863-9077-f8cad9d3c82b",
-                      areaName: null,
-                    },
-                  ],
-                },
-              ],
-            },
-          }),
-        );
+      rest.get("/api/v1/patch/all", (req, res, ctx) => {
+        return res(ctx.status(200), ctx.json([examplePatch]));
       }),
     );
+
     render(<App />, { url: "/" });
     await waitFor(() => expect(screen.queryByText("Loading...")).not.toBeInTheDocument());
     expect(screen.getAllByText(locale.title));
@@ -59,32 +61,25 @@ describe("<App />", () => {
       writable: true,
       value: cookieValue,
     });
+
+    const mismatchedPatch = {
+      ...examplePatch,
+      responsibleEntities: [
+        {
+          ...examplePatch.responsibleEntities[0],
+          contactDetails: {
+            emailAddress: "not-matching@hackney.gov.uk",
+          },
+        },
+      ],
+    };
+
     server.use(
-      rest.get("/api/v1/search/staff/", (req, res, ctx) => {
-        return res(
-          ctx.status(200),
-          ctx.json({
-            results: {
-              staff: [
-                {
-                  firstName: "Fake_Rupert",
-                  lastName: "Fake_Cruickshank",
-                  emailAddress: "unknown@hackney.gov.uk",
-                  patches: [
-                    {
-                      id: "5d59f3af-a692-49ae-9483-f631772ae3ec",
-                      name: null,
-                      areaId: "26e9426a-59a5-4863-9077-f8cad9d3c82b",
-                      areaName: null,
-                    },
-                  ],
-                },
-              ],
-            },
-          }),
-        );
+      rest.get("/api/v1/patch/all", (req, res, ctx) => {
+        return res(ctx.status(200), ctx.json([mismatchedPatch]));
       }),
     );
+
     render(<App />, { url: "/" });
     await waitFor(() => expect(screen.queryByText("Loading...")).not.toBeInTheDocument());
     expect(screen.getAllByText(locale.title));

--- a/src/services/locale.ts
+++ b/src/services/locale.ts
@@ -5,6 +5,8 @@ const locale = {
       noWorktrayResults: "No tasks found",
     },
   },
+  noPatchAssigned:
+    "You are not assigned to any patches. Please speak to your manager to be assigned a patch.",
   errors: {
     unableToFetchRecord: "There was a problem retrieving the record",
     unableToFetchRecordDescription:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1405,7 +1405,7 @@
 
 "@mtfh/common@https://github.com/LBHackney-IT/mtfh-common.git":
   version "0.0.1"
-  resolved "https://github.com/LBHackney-IT/mtfh-common.git#5e84e5ccac0242978190de4713d64f1ffeacc576"
+  resolved "https://github.com/LBHackney-IT/mtfh-common.git#fa51eacfe2105a590b594edefaf37b2cfdac18e2"
   dependencies:
     "@babel/preset-react" "^7.13.13"
     "@radix-ui/react-polymorphic" "^0.0.12"
@@ -1471,7 +1471,7 @@
 
 "@mtfh/personal-details@https://github.com/LBHackney-IT/mtfh-frontend-personal-details.git":
   version "1.0.0"
-  resolved "https://github.com/LBHackney-IT/mtfh-frontend-personal-details.git#8c9738dfe09102b997fd6bce9d6f57243c64eb32"
+  resolved "https://github.com/LBHackney-IT/mtfh-frontend-personal-details.git#48d2efc299fb6deff02d4b09257936629c75b8a4"
   dependencies:
     "@mtfh/common" "https://github.com/LBHackney-IT/mtfh-frontend-common.git"
     "@mtfh/worktray" "https://github.com/LBHackney-IT/mtfh-frontend-worktray.git"


### PR DESCRIPTION
Worktray was using the ES "staff" index to match a user's email address with a patch and area.

This PR makes it so the patches and areas API is used for this instead, allowing us to decommission the staff index so as not to need to keep it up to date in future.

Related PRs:
https://github.com/LBHackney-IT/housing-search-api/pull/213
https://github.com/LBHackney-IT/housing-search-shared/pull/72