### PR TITLE
Mr 864/use patches api for getting staff

### DIFF
--- a/src/app.test.tsx
+++ b/src/app.test.tsx
@@ -33,6 +33,12 @@ const examplePatch: Patch = {
 
 describe("<App />", () => {
   test("it renders correctly without cookie", async () => {
+    server.use(
+      rest.get("/api/v1/patch/all", (req, res, ctx) => {
+        return res(ctx.status(200), ctx.json([examplePatch]));
+      }),
+    );
+
     render(<App />, { url: "/" });
     await waitFor(() => expect(screen.queryByText("Loading...")).not.toBeInTheDocument());
     expect(screen.getAllByText(locale.title));

--- a/src/components/worktray-pagination/worktray-pagination.tsx
+++ b/src/components/worktray-pagination/worktray-pagination.tsx
@@ -18,7 +18,7 @@ interface WorktrayPaginationProps {
   pageRange?: number;
 }
 
-export const hasNoResult = (total: number | undefined) => {
+export const hasNoResult = (total: number | undefined): boolean => {
   return !total || total <= 0;
 };
 

--- a/src/views/worktray-view/worktray-view.tsx
+++ b/src/views/worktray-view/worktray-view.tsx
@@ -1,8 +1,8 @@
-import React, { useEffect } from "react";
+import React from "react";
 
 import jwt_decode from "jwt-decode";
 
-import { Patch, getAllPatchesAndAreas } from "@mtfh/common/lib/api/patch/v1";
+import { Patch } from "@mtfh/common/lib/api/patch/v1";
 import {
   Center,
   ErrorSummary,
@@ -11,9 +11,11 @@ import {
   Spinner,
   Text,
 } from "@mtfh/common/lib/components";
+import { useAxiosSWR } from "@mtfh/common/lib/http";
 
 import { WorktrayControls, WorktrayFilters, WorktrayList } from "../../components";
 import { WorktrayURLProvider } from "../../context/worktray-context";
+import { config } from "../../services";
 import locale from "../../services/locale";
 
 import "./styles.scss";
@@ -22,34 +24,24 @@ const getCookieValue = (name) =>
   document.cookie.match(`(^|;)\\s*${name}\\s*=\\s*([^;]+)`)?.pop() || "";
 
 export const WorktrayView = (): JSX.Element => {
-  const [showSpinner, setShowSpinner] = React.useState(true);
-  const [errorMessage, setErrorMessage] = React.useState("");
-  const [assignedPatch, setAssignedPatch] = React.useState<Patch>();
   const token = getCookieValue("hackneyToken");
   const { email: emailAddress } = token
     ? (jwt_decode(token) as { email: string })
     : { email: "" };
 
-  useEffect(() => {
-    setShowSpinner(true);
-    getAllPatchesAndAreas()
-      .then((data) => {
-        const patch = data.filter(
-          (patchOrArea) =>
-            patchOrArea.responsibleEntities[0]?.contactDetails?.emailAddress ===
-            emailAddress,
-        )[0];
-        setAssignedPatch(patch);
-      })
-      .catch((e) => {
-        setErrorMessage(e.message);
-      })
-      .finally(() => {
-        setShowSpinner(false);
-      });
-  }, [emailAddress]);
-
-  if (showSpinner) {
+  const { data, error } = useAxiosSWR<Patch[]>(
+    `${config.patchesAndAreasApiUrl}/patch/all`,
+  );
+  if (error) {
+    return (
+      <ErrorSummary
+        id="worktray-error"
+        title={locale.errors.unableToFetchRecord}
+        description={`${locale.errors.unableToFetchRecordDescription} - ${error.message}`}
+      />
+    );
+  }
+  if (!data) {
     return (
       <Center>
         <Spinner />
@@ -57,19 +49,16 @@ export const WorktrayView = (): JSX.Element => {
     );
   }
 
+  const assignedPatch = data.filter(
+    (patchOrArea) =>
+      patchOrArea.responsibleEntities[0]?.contactDetails?.emailAddress === emailAddress,
+  )[0];
+
   return (
     <>
       <hr className="divider" />
       <Layout>
         <Heading as="h1">{locale.title}</Heading>
-        {errorMessage && (
-          <ErrorSummary
-            id="worktray-error"
-            title={locale.errors.unableToFetchRecord}
-            description={`${locale.errors.unableToFetchRecordDescription} - ${errorMessage}`}
-          />
-        )}
-
         {assignedPatch ? (
           <WorktrayURLProvider
             sessionKey="worktray"

--- a/src/views/worktray-view/worktray-view.tsx
+++ b/src/views/worktray-view/worktray-view.tsx
@@ -36,7 +36,7 @@ export const WorktrayView = (): JSX.Element => {
       .then((data) => {
         const patch = data.filter(
           (patchOrArea) =>
-            patchOrArea.responsibleEntities[0].contactDetails.emailAddress ===
+            patchOrArea.responsibleEntities[0]?.contactDetails?.emailAddress ===
             emailAddress,
         )[0];
         setAssignedPatch(patch);


### PR DESCRIPTION
This is an attempt to reduce the flakiness of the E2E tests for Worktray by replicating the API request format as it was before, just with an in-place replacement of the housing search API with the patches API.

I suspect that the additional React hooks added in the other implementation were the cause of the E2E test flakiness.