### PR TITLE
SSI-831 Force terraform steps to use the correct SSH key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,13 +74,17 @@ commands:
       - checkout
       - run:
           name: get and init
+          # Ensure Git uses the correct key for SSH commands in this step. Otherwise the terraform init will fail when it tries to load the key from /home/circleci/.ssh while the key is added to /root/.ssh
+          # Without this the module download will fail
           command: |
+            export GIT_SSH_COMMAND="ssh -i /root/.ssh/id_rsa_fd8f60bef9c59321b9e35fdf3e6a8175"   
             cd ./terraform/<<parameters.environment>>/
             terraform get -update=true
             terraform init
       - run:
           name: apply
           command: |
+            export GIT_SSH_COMMAND="ssh -i /root/.ssh/id_rsa_fd8f60bef9c59321b9e35fdf3e6a8175"   
             cd ./terraform/<<parameters.environment>>/
             terraform apply -auto-approve
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,14 +77,14 @@ commands:
           # Ensure Git uses the correct key for SSH commands in this step. Otherwise the terraform init will fail when it tries to load the key from /home/circleci/.ssh while the key is added to /root/.ssh
           # Without this the module download will fail
           command: |
-            export GIT_SSH_COMMAND="ssh -i /root/.ssh/id_rsa_fd8f60bef9c59321b9e35fdf3e6a8175"   
+            export GIT_SSH_COMMAND="ssh -i ~/.ssh/id_rsa_fd8f60bef9c59321b9e35fdf3e6a8175"   
             cd ./terraform/<<parameters.environment>>/
             terraform get -update=true
             terraform init
       - run:
           name: apply
           command: |
-            export GIT_SSH_COMMAND="ssh -i /root/.ssh/id_rsa_fd8f60bef9c59321b9e35fdf3e6a8175"   
+            export GIT_SSH_COMMAND="ssh -i ~/.ssh/id_rsa_fd8f60bef9c59321b9e35fdf3e6a8175"   
             cd ./terraform/<<parameters.environment>>/
             terraform apply -auto-approve
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,14 +77,14 @@ commands:
           # Ensure Git uses the correct key for SSH commands in this step. Otherwise the terraform init will fail when it tries to load the key from /home/circleci/.ssh while the key is added to /root/.ssh
           # Without this the module download will fail
           command: |
-            export GIT_SSH_COMMAND="ssh -i ~/.ssh/id_rsa_fd8f60bef9c59321b9e35fdf3e6a8175"   
+            export GIT_SSH_COMMAND="ssh -i ~/.ssh/id_rsa_fd8f60bef9c59321b9e35fdf3e6a8175 -o IdentitiesOnly=yes"   
             cd ./terraform/<<parameters.environment>>/
             terraform get -update=true
             terraform init
       - run:
           name: apply
           command: |
-            export GIT_SSH_COMMAND="ssh -i ~/.ssh/id_rsa_fd8f60bef9c59321b9e35fdf3e6a8175"   
+            export GIT_SSH_COMMAND="ssh -i ~/.ssh/id_rsa_fd8f60bef9c59321b9e35fdf3e6a8175 -o IdentitiesOnly=yes"   
             cd ./terraform/<<parameters.environment>>/
             terraform apply -auto-approve
 jobs:


### PR DESCRIPTION
After adding multiple additional SSH keys under the same domain (github.com) to the CircleCi config the Terraform steps started failing.

After investigation it appears that the SSH command running in those steps is looking for the keys in the wrong location.

When additional keys are added with `add_ssh_keys` in the step, they are injected to `~/.ssh/` folder. However the step is looking for them in the  `/home/circleci/.ssh` folder. This update ensures all SSH commands that run in the Terraform steps use the correct key and location.

The file name is derived from the MD5 fingerprint of the public key as per the [CircleCi documentation](https://circleci.com/docs/guides/integration/add-ssh-key/)

UPDATE: prevent SSH from using any other keys than the one specificed by setting `-o IdentitiesOnly=yes`. This ensures it'll not fall back to other keys or try to use them before using the specified one.  We will only ever want to use the specified key and if that doesn't work the process should fail.