### PR TITLE
Fix Worktray not getting properly rendered when user logs in via Cognito auth flow.

### DIFF
--- a/src/app.test.tsx
+++ b/src/app.test.tsx
@@ -10,33 +10,33 @@ import App from "./app";
 import { locale } from "./services";
 
 function base64UrlEncode(string) {
-    const base64 = Buffer.from(string).toString('base64');
-    return base64.replace(/=+$/, '').replace(/\+/g, '-').replace(/\//g, '_');
+  const base64 = Buffer.from(string).toString("base64");
+  return base64.replace(/=+$/, "").replace(/\+/g, "-").replace(/\//g, "_");
 }
 
 function createJwt(payload) {
-    const header = {
-        alg: "none",
-        typ: "JWT"
-    };
-    const encodedHeader = base64UrlEncode(JSON.stringify(header));
-    const encodedPayload = base64UrlEncode(JSON.stringify(payload));
+  const header = {
+    alg: "none",
+    typ: "JWT",
+  };
+  const encodedHeader = base64UrlEncode(JSON.stringify(header));
+  const encodedPayload = base64UrlEncode(JSON.stringify(payload));
 
-    return `${encodedHeader}.${encodedPayload}.`;
+  return `${encodedHeader}.${encodedPayload}.`;
 }
 
-const cookieValue = ({tokenPayload, isCognito}) =>
-  `${isCognito ? "hackneyCognitoToken" : "hackneyToken"}=${createJwt(tokenPayload)}`
+const cookieValue = ({ tokenPayload, isCognito }) =>
+  `${isCognito ? "hackneyCognitoToken" : "hackneyToken"}=${createJwt(tokenPayload)}`;
 
 const tokenPayloadUserNoPatches = {
   email: "no.patches@hackney.gov.uk",
   name: "No Patches",
-}
+};
 
 const tokenPayloadUserWithPatches = {
   email: "yes.patches@hackney.gov.uk",
   name: "Yes Patches",
-}
+};
 
 const examplePatch = (responsibleEmail: string): Patch => {
   return {
@@ -57,7 +57,7 @@ const examplePatch = (responsibleEmail: string): Patch => {
     ],
     versionNumber: 0,
   };
-}
+};
 
 describe("<App />", () => {
   test("it renders correctly without cookie", async () => {
@@ -68,40 +68,56 @@ describe("<App />", () => {
     );
 
     try {
-        render(<App />, { url: "/" });
-        await waitFor(() => expect(screen.queryByText("Loading...")).not.toBeInTheDocument());
-        throw new Error("The component rendered successfully, but an error was expected.");
+      render(<App />, { url: "/" });
+      await waitFor(() =>
+        expect(screen.queryByText("Loading...")).not.toBeInTheDocument(),
+      );
+      throw new Error("The component rendered successfully, but an error was expected.");
     } catch (error) {
-        expect(error).toHaveProperty('message', 'No token found!');
+      expect(error).toHaveProperty("message", "No token found!");
     }
   });
 
-  test.each([false, true])("it renders correctly with cookie", async (isCognitoToken: boolean) => {
-    Object.defineProperty(document, "cookie", {
-      writable: true,
-      value: cookieValue({tokenPayload: tokenPayloadUserWithPatches, isCognito: isCognitoToken}),
-    });
+  test.each([false, true])(
+    "it renders correctly with cookie",
+    async (isCognitoToken: boolean) => {
+      Object.defineProperty(document, "cookie", {
+        writable: true,
+        value: cookieValue({
+          tokenPayload: tokenPayloadUserWithPatches,
+          isCognito: isCognitoToken,
+        }),
+      });
 
-    server.use(
-      rest.get("/api/v1/patch/all", (req, res, ctx) => {
-        return res(ctx.status(200), ctx.json([examplePatch(tokenPayloadUserWithPatches.email)]));
-      }),
-    );
+      server.use(
+        rest.get("/api/v1/patch/all", (req, res, ctx) => {
+          return res(
+            ctx.status(200),
+            ctx.json([examplePatch(tokenPayloadUserWithPatches.email)]),
+          );
+        }),
+      );
 
-    render(<App />, { url: "/" });
-    await waitFor(() => expect(screen.queryByText("Loading...")).not.toBeInTheDocument());
-    expect(screen.getAllByText(locale.title));
-  });
+      render(<App />, { url: "/" });
+      await waitFor(() =>
+        expect(screen.queryByText("Loading...")).not.toBeInTheDocument(),
+      );
+      expect(screen.getAllByText(locale.title));
+    },
+  );
 
   test("it renders correctly with cookie but no matching email", async () => {
     Object.defineProperty(document, "cookie", {
       writable: true,
-      value: cookieValue({tokenPayload: tokenPayloadUserNoPatches, isCognito: false}),
+      value: cookieValue({ tokenPayload: tokenPayloadUserNoPatches, isCognito: false }),
     });
 
     server.use(
       rest.get("/api/v1/patch/all", (req, res, ctx) => {
-        return res(ctx.status(200), ctx.json([examplePatch("non-matching-email@hackney.gov.uk")]));
+        return res(
+          ctx.status(200),
+          ctx.json([examplePatch("non-matching-email@hackney.gov.uk")]),
+        );
       }),
     );
 

--- a/src/app.test.tsx
+++ b/src/app.test.tsx
@@ -50,7 +50,6 @@ const examplePatch = (responsibleEmail: string): Patch => {
         id: "5d59f3af-a692-49ae-9483-f631772ae3ec",
         name: "",
         contactDetails: {
-          // Has to be a different email to that of cookie
           emailAddress: responsibleEmail,
         },
         responsibleType: "HousingOfficer",
@@ -63,6 +62,22 @@ const examplePatch = (responsibleEmail: string): Patch => {
 const token = createJwt({ user: "exampleUser" });
 
 describe("<App />", () => {
+  test("it renders correctly without cookie", async () => {
+    server.use(
+      rest.get("/api/v1/patch/all", (req, res, ctx) => {
+        return res(ctx.status(200), ctx.json([examplePatch("tests@hackney.gov.uk")]));
+      }),
+    );
+
+    try {
+        render(<App />, { url: "/" });
+        await waitFor(() => expect(screen.queryByText("Loading...")).not.toBeInTheDocument());
+        throw new Error("The component rendered successfully, but an error was expected.");
+    } catch (error) {
+        expect(error).toHaveProperty('message', 'No token found!');
+    }
+  });
+
   test("it renders correctly with cookie", async () => {
     Object.defineProperty(document, "cookie", {
       writable: true,

--- a/src/app.test.tsx
+++ b/src/app.test.tsx
@@ -59,8 +59,6 @@ const examplePatch = (responsibleEmail: string): Patch => {
   };
 }
 
-const token = createJwt({ user: "exampleUser" });
-
 describe("<App />", () => {
   test("it renders correctly without cookie", async () => {
     server.use(

--- a/src/app.test.tsx
+++ b/src/app.test.tsx
@@ -78,10 +78,10 @@ describe("<App />", () => {
     }
   });
 
-  test("it renders correctly with cookie", async () => {
+  test.each([false, true])("it renders correctly with cookie", async (isCognitoToken: boolean) => {
     Object.defineProperty(document, "cookie", {
       writable: true,
-      value: cookieValue({tokenPayload: tokenPayloadUserWithPatches, isCognito: false}),
+      value: cookieValue({tokenPayload: tokenPayloadUserWithPatches, isCognito: isCognitoToken}),
     });
 
     server.use(

--- a/src/app.test.tsx
+++ b/src/app.test.tsx
@@ -9,51 +9,69 @@ import { Patch } from "@mtfh/common/lib/api/patch/v1";
 import App from "./app";
 import { locale } from "./services";
 
-const cookieValue =
-  "hackneyToken=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMTUwOTc4MjMzNDMwODYzNjM3NzkiLCJlbWFpbCI6InRlc3RzQGhhY2tuZXkuZ292LnVrIiwiaXNzIjoiSGFja25leSIsIm5hbWUiOiJUZXN0IFRlc3QiLCJpYXQiOjEyMzQ1Njc4OTB9.MRnNHSYMi9majpommvHmSuLMb0tnMvYlX7AXs2DyO6U";
+function base64UrlEncode(string) {
+    const base64 = Buffer.from(string).toString('base64');
+    return base64.replace(/=+$/, '').replace(/\+/g, '-').replace(/\//g, '_');
+}
 
-const examplePatch: Patch = {
-  id: "5d59f3af-a692-49ae-9483-f631772ae3ec",
-  name: "Fake_Rupert Fake_Cruickshank",
-  parentId: "26e9426a-59a5-4863-9077-f8cad9d3c82b",
-  domain: "MMH",
-  patchType: "patch",
-  responsibleEntities: [
-    {
-      id: "5d59f3af-a692-49ae-9483-f631772ae3ec",
-      name: "",
-      contactDetails: {
-        emailAddress: "tests@hackney.gov.uk",
+function createJwt(payload) {
+    const header = {
+        alg: "none",
+        typ: "JWT"
+    };
+    const encodedHeader = base64UrlEncode(JSON.stringify(header));
+    const encodedPayload = base64UrlEncode(JSON.stringify(payload));
+
+    return `${encodedHeader}.${encodedPayload}.`;
+}
+
+const cookieValue = ({tokenPayload, isCognito}) =>
+  `${isCognito ? "hackneyCognitoToken" : "hackneyToken"}=${createJwt(tokenPayload)}`
+
+const tokenPayloadUserNoPatches = {
+  email: "no.patches@hackney.gov.uk",
+  name: "No Patches",
+}
+
+const tokenPayloadUserWithPatches = {
+  email: "yes.patches@hackney.gov.uk",
+  name: "Yes Patches",
+}
+
+const examplePatch = (responsibleEmail: string): Patch => {
+  return {
+    id: "5d59f3af-a692-49ae-9483-f631772ae3ec",
+    name: "Fake_Rupert Fake_Cruickshank",
+    parentId: "26e9426a-59a5-4863-9077-f8cad9d3c82b",
+    domain: "MMH",
+    patchType: "patch",
+    responsibleEntities: [
+      {
+        id: "5d59f3af-a692-49ae-9483-f631772ae3ec",
+        name: "",
+        contactDetails: {
+          // Has to be a different email to that of cookie
+          emailAddress: responsibleEmail,
+        },
+        responsibleType: "HousingOfficer",
       },
-      responsibleType: "HousingOfficer",
-    },
-  ],
-  versionNumber: 0,
-};
+    ],
+    versionNumber: 0,
+  };
+}
+
+const token = createJwt({ user: "exampleUser" });
 
 describe("<App />", () => {
-  test("it renders correctly without cookie", async () => {
-    server.use(
-      rest.get("/api/v1/patch/all", (req, res, ctx) => {
-        return res(ctx.status(200), ctx.json([examplePatch]));
-      }),
-    );
-
-    render(<App />, { url: "/" });
-    await waitFor(() => expect(screen.queryByText("Loading...")).not.toBeInTheDocument());
-    expect(screen.getAllByText(locale.title));
-    expect(screen.getAllByText(locale.noPatchAssigned));
-  });
-
   test("it renders correctly with cookie", async () => {
     Object.defineProperty(document, "cookie", {
       writable: true,
-      value: cookieValue,
+      value: cookieValue({tokenPayload: tokenPayloadUserWithPatches, isCognito: false}),
     });
 
     server.use(
       rest.get("/api/v1/patch/all", (req, res, ctx) => {
-        return res(ctx.status(200), ctx.json([examplePatch]));
+        return res(ctx.status(200), ctx.json([examplePatch(tokenPayloadUserWithPatches.email)]));
       }),
     );
 
@@ -65,24 +83,12 @@ describe("<App />", () => {
   test("it renders correctly with cookie but no matching email", async () => {
     Object.defineProperty(document, "cookie", {
       writable: true,
-      value: cookieValue,
+      value: cookieValue({tokenPayload: tokenPayloadUserNoPatches, isCognito: false}),
     });
-
-    const mismatchedPatch = {
-      ...examplePatch,
-      responsibleEntities: [
-        {
-          ...examplePatch.responsibleEntities[0],
-          contactDetails: {
-            emailAddress: "not-matching@hackney.gov.uk",
-          },
-        },
-      ],
-    };
 
     server.use(
       rest.get("/api/v1/patch/all", (req, res, ctx) => {
-        return res(ctx.status(200), ctx.json([mismatchedPatch]));
+        return res(ctx.status(200), ctx.json([examplePatch("non-matching-email@hackney.gov.uk")]));
       }),
     );
 

--- a/src/views/worktray-view/worktray-view.tsx
+++ b/src/views/worktray-view/worktray-view.tsx
@@ -23,8 +23,18 @@ import "./styles.scss";
 const getCookieValue = (name) =>
   document.cookie.match(`(^|;)\\s*${name}\\s*=\\s*([^;]+)`)?.pop() || "";
 
+const getToken = () => {
+  const cognitoToken = getCookieValue("hackneyCognitoToken");
+  const legacyToken = getCookieValue("hackneyToken");
+
+  if (cognitoToken) return cognitoToken;
+  if (legacyToken) return legacyToken;
+
+  throw new Error("No token found!");
+};
+
 export const WorktrayView = (): JSX.Element => {
-  const token = getCookieValue("hackneyToken");
+  const token = getToken();
   const { email: emailAddress } = token
     ? (jwt_decode(token) as { email: string })
     : { email: "" };

--- a/src/views/worktray-view/worktray-view.tsx
+++ b/src/views/worktray-view/worktray-view.tsx
@@ -35,9 +35,10 @@ const getToken = () => {
 
 export const WorktrayView = (): JSX.Element => {
   const token = getToken();
-  const { email: emailAddress } = token
-    ? (jwt_decode(token) as { email: string })
-    : { email: "" };
+
+  // If token does not exist, this line does not get reached due to "Not token" error.
+  // This MFE should not get rendered when no token is present.
+  const { email: emailAddress } = jwt_decode(token) as { email: string };
 
   const { data, error } = useAxiosSWR<Patch[]>(
     `${config.patchesAndAreasApiUrl}/patch/all`,

--- a/src/views/worktray-view/worktray-view.tsx
+++ b/src/views/worktray-view/worktray-view.tsx
@@ -27,8 +27,12 @@ const getToken = () => {
   const cognitoToken = getCookieValue("hackneyCognitoToken");
   const legacyToken = getCookieValue("hackneyToken");
 
-  if (cognitoToken) return cognitoToken;
-  if (legacyToken) return legacyToken;
+  if (cognitoToken) {
+    return cognitoToken;
+  }
+  if (legacyToken) {
+    return legacyToken;
+  }
 
   throw new Error("No token found!");
 };


### PR DESCRIPTION
# What:
 - Make MFE work with Cognito token.

# Why:
 - Currently the patches on the dashboard only get displayed when user logs in with Legacy token, but not when they log in with Cognito token.

# Notes:
 - Updated the tests to get rid of hard-coded fake secret.
 - Made it so the FE throws when no token is encountered. This is because if the MFE is attempted to get rendered when no token is present, this means something has gone wrong.